### PR TITLE
Stabilize rendering loop and add background music

### DIFF
--- a/src/components/CleanPerceptionShift.tsx
+++ b/src/components/CleanPerceptionShift.tsx
@@ -20,6 +20,7 @@ import type { User, Session } from '@supabase/supabase-js';
 import { toast } from '@/hooks/use-toast';
 import { Trophy, Crown, Target, ArrowLeft } from 'lucide-react';
 import { CrateShop } from './CrateShop';
+import { useBackgroundMusic } from '@/hooks/useBackgroundMusic';
 
 
 type GameScreen = 'splash' | 'menu' | 'game' | 'leaderboard' | 'shop' | 'inventory' | 'crateShop' | 'engagementHub';
@@ -33,6 +34,15 @@ export const CleanPerceptionShift = () => {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
   const [isGuest, setIsGuest] = useState(false);
+  const { start: startMusic, stop: stopMusic } = useBackgroundMusic();
+
+  useEffect(() => {
+    if (currentScreen === 'game') {
+      startMusic();
+    } else {
+      stopMusic();
+    }
+  }, [currentScreen, startMusic, stopMusic]);
 
   useEffect(() => {
     let mounted = true;

--- a/src/components/CompleteGameCanvas.tsx
+++ b/src/components/CompleteGameCanvas.tsx
@@ -330,7 +330,7 @@ export const CompleteGameCanvas = () => {
       currentRoomRef.current = { ...currentRoom };
       roomNumberRef.current = roomsCleared + 1;
     }
-  }, [currentRoom.id, roomsCleared, isPlaying, player.x, player.y]);
+  }, [currentRoom.id, roomsCleared, isPlaying]);
 
     return (
     <div className="w-full h-full flex items-center justify-center relative">

--- a/src/hooks/useBackgroundMusic.ts
+++ b/src/hooks/useBackgroundMusic.ts
@@ -1,0 +1,57 @@
+import { useRef, useCallback } from 'react';
+
+export function useBackgroundMusic() {
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const timeoutRef = useRef<number>();
+
+  const start = useCallback(() => {
+    if (audioCtxRef.current) return;
+    const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+    const ctx = new AudioCtx();
+    audioCtxRef.current = ctx;
+
+    const master = ctx.createGain();
+    master.gain.value = 0.05;
+    master.connect(ctx.destination);
+
+    const tempo = 120;
+    const beat = 60 / tempo;
+    const pattern = [261.63, 329.63, 392.0, 523.25]; // C major arpeggio
+
+    const schedule = (startTime: number) => {
+      pattern.forEach((freq, i) => {
+        const osc = ctx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.value = freq;
+
+        const gain = ctx.createGain();
+        gain.gain.setValueAtTime(0.15, startTime + i * beat);
+        gain.gain.exponentialRampToValueAtTime(0.001, startTime + i * beat + beat * 0.9);
+
+        osc.connect(gain);
+        gain.connect(master);
+
+        osc.start(startTime + i * beat);
+        osc.stop(startTime + i * beat + beat);
+      });
+
+      timeoutRef.current = window.setTimeout(() => {
+        schedule(ctx.currentTime);
+      }, pattern.length * beat * 1000);
+    };
+
+    schedule(ctx.currentTime);
+  }, []);
+
+  const stop = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    if (audioCtxRef.current) {
+      audioCtxRef.current.close();
+      audioCtxRef.current = null;
+    }
+  }, []);
+
+  return { start, stop };
+}


### PR DESCRIPTION
## Summary
- ensure game loop uses stable store access to prevent reinitialization each frame
- play simple chiptune background music while game screen is active
- avoid unnecessary effect reruns when syncing room state

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7ef27a96483229be55fdd74046622